### PR TITLE
Glm/turn on enabled fembs upfront

### DIFF
--- a/plugins/ProtoWIBConfigurator.cpp
+++ b/plugins/ProtoWIBConfigurator.cpp
@@ -172,7 +172,7 @@ ProtoWIBConfigurator::do_settings(const data_t& payload)
   else
   {
     TLOG_DEBUG(0) << "Running Checked Reset on the WIB";
-    wib->CheckedResetWIBAndCfgDTS(conf.local_clock, conf.partition_number, conf.dts_source);    
+    wib->CheckedResetWIBAndCfgDTS(conf.local_clock, conf.partition_number, conf.dts_source, 1); // GLM: last param =1 means we are going to wait to reach 0x8    
     TLOG_DEBUG(0) << "Finished Checked Reset on the WIB";
     if (daqMode == WIB::FELIX)
     {                                                  


### PR DESCRIPTION
This patch turns on all enabled FEMBs before starting to configure them individually. It was shown that this is necessary to configure the VD coldbox.