### PR TITLE
add options for configuration generation; bump tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(wibmod VERSION 1.4.2)
+project(wibmod VERSION 1.4.3)
 
 find_package(daq-cmake REQUIRED)
 

--- a/plugins/WIBConfigurator.cpp
+++ b/plugins/WIBConfigurator.cpp
@@ -70,7 +70,7 @@ WIBConfigurator::populate_femb_conf(wib::ConfigureWIB::ConfigureFEMB *femb_conf,
   femb_conf->set_leak(conf.leak);
   femb_conf->set_leak_10x(conf.leak_10x != 0);
   femb_conf->set_ac_couple(conf.ac_couple);
-  femb_conf->set_buffer(conf.buffer);
+  femb_conf->set_buffer(conf.buffering);
 
   femb_conf->set_strobe_skip(conf.strobe_skip);
   femb_conf->set_strobe_delay(conf.strobe_delay);

--- a/python/wibmod/wibapp/wibapp_gen.py
+++ b/python/wibmod/wibapp/wibapp_gen.py
@@ -22,7 +22,7 @@ from daqconf.core.daqmodule import DAQModule
 #===============================================================================
 def get_wib_app(nickname, 
                 endpoint, 
-                version,
+                version, gain, shaping_time, baseline, pulse_dac, pulser, buf,
                 host="localhost"):
     '''
     Here an entire application consisting only of one (Proto)WIBConfigurator module is generated. 
@@ -49,10 +49,11 @@ def get_wib_app(nickname,
                              plugin = 'WIBConfigurator',
                              conf = wib.WIBConf(wib_addr = endpoint,
                                  settings = wib.WIBSettings(
-                                     femb0 = wib.FEMBSettings(),
-                                     femb1 = wib.FEMBSettings(),
-                                     femb2 = wib.FEMBSettings(),
-                                     femb3 = wib.FEMBSettings()
+                                     pulser = pulser,
+                                     femb0 = wib.FEMBSettings(gain=gain, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf),
+                                     femb1 = wib.FEMBSettings(gain=gain, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf),
+                                     femb2 = wib.FEMBSettings(gain=gain, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf),
+                                     femb3 = wib.FEMBSettings(gain=gain, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf)
                                      )
                                  )
                              )]

--- a/schema/wibmod/wibconfigurator.jsonnet
+++ b/schema/wibmod/wibconfigurator.jsonnet
@@ -9,31 +9,31 @@ local types = {
 
     value : s.number("Value", "u4", doc="A digitally variable value"),
     
-    bool : s.number("Bool", "u4", doc="1/0 for enable/disabled or true/false"),
+    bool : s.boolean("Bool", doc="true/false"),
 
     femb_settings: s.record("FEMBSettings", [
     
         s.field("enabled", self.bool, 1,
                 doc="True of FEMB should be configured and read out by WIB"),
     
-        s.field("test_cap", self.bool, 0, 
+        s.field("test_cap", self.bool, false, 
                 doc="Enable the test capacitor"), 
         s.field("gain", self.option, 0, 
                 doc="Channel gain selector: 14, 25, 7.8, 4.7 mV/fC (0 - 3)" ), 
-        s.field("peak_time", self.option, 0,
+        s.field("peak_time", self.option, 3,
                 doc="Channel peak time selector: 1.0, 0.5, 3, 2 us (0 - 3)"),
-        s.field("baseline", self.option, 0,
-                doc="Baseline selector: 0 (900 mV), 1 (200 mV))"),
+        s.field("baseline", self.option, 2,
+                doc="Baseline selector: 0 (900 mV), 1 (200 mV), 2 (200 mV collection, 900 mV induction)"),
         s.field("pulse_dac", self.value, 0,
                 doc="Pulser DAC setting [0-63]"),
                 
         s.field("leak", self.option, 0,
                 doc="Leak current selector: 0 (500 pA), 1 (100 pA)"),
-        s.field("leak_10x", self.bool, 0,
+        s.field("leak_10x", self.bool, false,
                 doc="Multiply leak current by 10 if true"),
-        s.field("ac_couple", self.bool, 0,
+        s.field("ac_couple", self.bool, false,
                 doc="false (DC coupling), true (AC coupling)"),
-        s.field("buffer", self.option, 0,
+        s.field("buffering", self.option, 0,
                 doc="0 (no buffer), 1 (se buffer), 2 (sedc buffer)"),
                 
         s.field("strobe_skip", self.value, 255,
@@ -47,11 +47,11 @@ local types = {
 
     settings: s.record("WIBSettings", [
   
-        s.field("cold", self.bool, 0,
+        s.field("cold", self.bool, false,
                 doc="True if the front end electronics are COLD (77k)"),
-        s.field("pulser", self.bool, 0,
+        s.field("pulser", self.bool, false,
                 doc="True if the calibration pulser should be enabled"),
-        s.field("adc_test_pattern", self.bool, 0,
+        s.field("adc_test_pattern", self.bool, false,
                 doc="True if the COLDADC test pattern should be enabled"),
                 
         s.field("femb0", self.femb_settings, doc="Settings for FEMB in slot 0"),

--- a/scripts/wibconf_gen
+++ b/scripts/wibconf_gen
@@ -30,6 +30,12 @@ import click
 @click.option('-w', '--wibserver', nargs=2, multiple=True) # e.g. -w TESTSTAND tcp://192.168.121.1:1234
 @click.option('-p', '--protowib', nargs=2, multiple=True) # e.g. -p TESTSTAND 192.168.121.1
 @click.option('--host-wib', default='localhost', help='Host to run the WIB sw app on')
+@click.option('--gain', type=click.IntRange(0,3), default=0, help='Channel gain selector: 14, 25, 7.8, 4.7 mV/fC (0 - 3)')
+@click.option('--shaping-time', type=click.IntRange(0,3), default=3, help='Channel peak time selector: 1.0, 0.5, 3, 2 us (0 - 3)')
+@click.option('--baseline', type=click.IntRange(0,2), default=2, help='Baseline selector: 0 (900 mV), 1 (200 mV), 2 (200 mV collection, 900 mV induction)')
+@click.option('--pulse-dac', type=click.IntRange(0,63), default=0, help='Pulser DAC setting [0-63]')
+@click.option('--pulser', default=False, is_flag=True, help="Switch to enable pulser")
+@click.option('--buffering', type=click.IntRange(0,2), default=0, help='0 (no buffer), 1 (se buffer), 2 (sedc buffer)')
 @click.option('--opmon-impl', type=click.Choice(['json','cern','pocket'], case_sensitive=False),default='json', help="Info collector service implementation to use")
 @click.option('--ers-impl', type=click.Choice(['local','cern','pocket'], case_sensitive=False), default='local', help="ERS destination (Kafka used for cern and pocket)")
 @click.option('--pocket-url', default='127.0.0.1', help="URL for connecting to Pocket services")
@@ -38,7 +44,7 @@ import click
 @click.option('--use-k8s', is_flag=True, default=False, help="Whether to use k8s")
 @click.argument('json_dir', type=click.Path())
 
-def cli(wibserver, protowib, host_wib, opmon_impl, ers_impl, pocket_url, debug, image, use_k8s, json_dir):
+def cli(wibserver, protowib, host_wib, gain, shaping_time, baseline, pulse_dac, pulser, buffering, opmon_impl, ers_impl, pocket_url, debug, image, use_k8s, json_dir):
 
     if exists(json_dir):
         raise RuntimeError(f"Directory {json_dir} already exists")
@@ -86,7 +92,7 @@ def cli(wibserver, protowib, host_wib, opmon_impl, ers_impl, pocket_url, debug, 
         the_system.apps[k]=wibapp_gen.get_wib_app(k,v,1,host_wib)
 
     for k,v in wibservers.items():
-        the_system.apps[k]=wibapp_gen.get_wib_app(k,v,2,host_wib)
+        the_system.apps[k]=wibapp_gen.get_wib_app(k,v,2, gain, shaping_time, baseline, pulse_dac, pulser, buffering, host_wib)
 
     ####################################################################
     # Application command data generation


### PR DESCRIPTION
while generating configurations for the coldbox I realised that a number of options were missing requiring manual modification of json files. This is now improved.