### PR TITLE
Addition of gain_match and detector_type fields for WIB configuration

### DIFF
--- a/plugins/WIBConfigurator.cpp
+++ b/plugins/WIBConfigurator.cpp
@@ -66,6 +66,7 @@ WIBConfigurator::populate_femb_conf(wib::ConfigureWIB::ConfigureFEMB *femb_conf,
   femb_conf->set_peak_time(conf.peak_time);
   femb_conf->set_baseline(conf.baseline);
   femb_conf->set_pulse_dac(conf.pulse_dac);
+  femb_conf->set_gain_match(conf.gain_match);
 
   femb_conf->set_leak(conf.leak);
   femb_conf->set_leak_10x(conf.leak_10x != 0);
@@ -89,6 +90,8 @@ WIBConfigurator::do_conf(const data_t& payload)
 
   TLOG_DEBUG(0) << get_name() << " successfully initialized";
   
+  check_timing();
+
   do_settings(conf.settings);
 
   check_timing();
@@ -156,6 +159,7 @@ WIBConfigurator::do_settings(const data_t& payload)
   req.set_cold(conf.cold);
   req.set_pulser(conf.pulser);
   req.set_adc_test_pattern(conf.adc_test_pattern);
+  req.set_detector_type(conf.detector_type);
 
   for(size_t iFEMB = 0; iFEMB < 4; iFEMB++)
   {

--- a/plugins/WIBConfigurator.cpp
+++ b/plugins/WIBConfigurator.cpp
@@ -114,28 +114,12 @@ WIBConfigurator::check_timing()
   } 
   
   TLOG_DEBUG(0) << get_name() << " timing status incorrect as " << endpoint_status; 
-  wib::Poke* req2;
-  wib::Status rep2;
-  req2->set_addr(0xA00C000C); //See WIB firmware document, this is the register for timing edge select (0xA00C000C);
-  req2->set_value(0x1);
 
-  wib->send_command(*req2,rep2);
-  if(!rep2.success())
-  {
-    TLOG_DEBUG(0) << get_name() << " failed to write timing edge switch";
-    throw ConfigurationFailed(ERS_HERE, get_name(), rep2.extra());
-  }
+  wib::ResetTiming req2;
+  wib::GetTimingStatus::TimingStatus rep2;
+  wib->send_command(req2,rep2);
 
-  wib::ResetTiming req3;
-  wib::GetTimingStatus::TimingStatus rep3;
-  wib->send_command(req3,rep3);
-
-  //Because I've seen the status change after this initial reset
-  TLOG_DEBUG(0) << get_name() << " Checking timing status";
-  wib::GetTimingStatus req4;
-  wib::GetTimingStatus::TimingStatus rep4;  wib->send_command(req4,rep4);
-
-  endpoint_status = rep.ept_status() & 0xf;
+  endpoint_status = rep2.ept_status() & 0xf;
   if (endpoint_status == 0x8)
   {
     TLOG_DEBUG(0) << get_name() << " timing status correct as " << endpoint_status;

--- a/python/wibmod/wibapp/wibapp_gen.py
+++ b/python/wibmod/wibapp/wibapp_gen.py
@@ -22,7 +22,7 @@ from daqconf.core.daqmodule import DAQModule
 #===============================================================================
 def get_wib_app(nickname, 
                 endpoint, 
-                version, gain, shaping_time, baseline, pulse_dac, pulser, buf,
+                version, gain, gain_match, shaping_time, baseline, pulse_dac, pulser, buf, detector_type,
                 host="localhost"):
     '''
     Here an entire application consisting only of one (Proto)WIBConfigurator module is generated. 
@@ -50,10 +50,11 @@ def get_wib_app(nickname,
                              conf = wib.WIBConf(wib_addr = endpoint,
                                  settings = wib.WIBSettings(
                                      pulser = pulser,
-                                     femb0 = wib.FEMBSettings(gain=gain, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf, test_cap=pulser),
-                                     femb1 = wib.FEMBSettings(gain=gain, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf, test_cap=pulser),
-                                     femb2 = wib.FEMBSettings(gain=gain, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf, test_cap=pulser),
-                                     femb3 = wib.FEMBSettings(gain=gain, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf, test_cap=pulser)
+                                     detector_type = detector_type,
+                                     femb0 = wib.FEMBSettings(gain=gain, gain_match=gain_match, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf, test_cap=pulser),
+                                     femb1 = wib.FEMBSettings(gain=gain, gain_match=gain_match, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf, test_cap=pulser),
+                                     femb2 = wib.FEMBSettings(gain=gain, gain_match=gain_match, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf, test_cap=pulser),
+                                     femb3 = wib.FEMBSettings(gain=gain, gain_match=gain_match, peak_time=shaping_time, baseline=baseline, pulse_dac=pulse_dac, buffering=buf, test_cap=pulser)
                                      )
                                  )
                              )]

--- a/schema/wibmod/confgen.jsonnet
+++ b/schema/wibmod/confgen.jsonnet
@@ -15,7 +15,8 @@ local cs = {
   gain_selector:         s.number('gain',         dtype='i4', constraints=nc(minimum=0, maximum=3),  doc='Channel gain selector: 14, 25, 7.8, 4.7 mV/fC (0 - 3)'),
   pulse_dac_selector:    s.number('pulse_dac',    dtype='i4', constraints=nc(minimum=0, maximum=63), doc='Pulser DAC setting [0-63]'),
   buffering_selector:    s.number('buffering',    dtype='i4', constraints=nc(minimum=0, maximum=2),  doc='0 (no buffer), 1 (se buffer), 2 (sedc buffer)'),
-
+  detector_type_selector:s.number('detector_type',dtype='i4', constraints=nc(minimum=0, maximum=3),  doc='Detector type: 0 (use WIB default), 1 (upper APA), 2 (lower APA), 3 (CRP)'), 
+ 
   wib: s.record('wib', [
     s.field('name',    daqconf.Str, default="", doc='server name (?)'),
     s.field('address', daqconf.Str, default="", doc='server IP (?)'),
@@ -32,7 +33,9 @@ local cs = {
     s.field('baseline',     self.baseline_selector,     default=2,           doc='Baseline selector: 0 (900 mV), 1 (200 mV), 2 (200 mV collection, 900 mV induction)'),
     s.field('pulse_dac',    self.pulse_dac_selector,    default=0,           doc='Pulser DAC setting [0-63]'),
     s.field('pulser',       daqconf.Flag,               default=false,       doc="Switch to enable pulser"),
+    s.field('gain_match',   daqconf.Flag,               default=true,        doc="Switch to enable gain matching for pulser amplitude"),
     s.field('buffering',    self.buffering_selector,    default=0,           doc='0 (no buffer), 1 (se buffer), 2 (sedc buffer)'),
+    s.field('detector_type',self.detector_type_selector,default=0,           doc='Detector type: 0 (use WIB default), 1 (upper APA), 2 (lower APA), 3 (CRP)'),
   ]),
 
   wibmod_gen: s.record('wibmod_gen', [

--- a/schema/wibmod/wibconfigurator.jsonnet
+++ b/schema/wibmod/wibconfigurator.jsonnet
@@ -26,6 +26,8 @@ local types = {
                 doc="Baseline selector: 0 (900 mV), 1 (200 mV), 2 (200 mV collection, 900 mV induction)"),
         s.field("pulse_dac", self.value, 0,
                 doc="Pulser DAC setting [0-63]"),
+        s.field("gain_match", self.bool, true,
+                doc="Enable pulser DAC gain matching"),
                 
         s.field("leak", self.option, 0,
                 doc="Leak current selector: 0 (500 pA), 1 (100 pA)"),
@@ -51,6 +53,8 @@ local types = {
                 doc="True if the front end electronics are COLD (77k)"),
         s.field("pulser", self.bool, false,
                 doc="True if the calibration pulser should be enabled"),
+        s.field("detector_type", self.value, 0,
+                doc="Detector type selector: upper APA (0), lower APA (1), CRP (2)"),
         s.field("adc_test_pattern", self.bool, false,
                 doc="True if the COLDADC test pattern should be enabled"),
                 

--- a/schema/wibmod/wibconfigurator.jsonnet
+++ b/schema/wibmod/wibconfigurator.jsonnet
@@ -54,7 +54,7 @@ local types = {
         s.field("pulser", self.bool, false,
                 doc="True if the calibration pulser should be enabled"),
         s.field("detector_type", self.value, 0,
-                doc="Detector type selector: upper APA (0), lower APA (1), CRP (2)"),
+                doc="Detector type selector: WIB default (0), upper APA (1), lower APA (2), CRP (3)"),
         s.field("adc_test_pattern", self.bool, false,
                 doc="True if the COLDADC test pattern should be enabled"),
                 

--- a/scripts/wibconf_gen
+++ b/scripts/wibconf_gen
@@ -81,11 +81,13 @@ def cli(config, debug, json_dir):
             endpoint     = v,
             version      = 2,
             gain         = wibmod.gain,
+	    gain_match   = wibmod.gain_match,	   
             shaping_time = wibmod.shaping_time,
             baseline     = wibmod.baseline,
             pulse_dac    = wibmod.pulse_dac,
             pulser       = wibmod.pulser,
             buf          = wibmod.buffering,
+	    detector_type= wibmod.detector_type,
             host         = wibmod.host_wib
         )
 

--- a/src/wib.proto
+++ b/src/wib.proto
@@ -113,7 +113,8 @@ message ConfigureWIB {
         bool leak_10x = 8; // multiply leak by 10 if true
         bool ac_couple = 9; // false (DC coupling), true (AC coupling)
         uint32 buffer = 10; // 0 (no buffer), 1 (se buffer), 2 (sedc buffer)
-        
+	bool gain_match = 14; //0 is enabled, 1 is disabled, bit SGP in LArASIC datasheet        
+
         // COLDATA calibration strobe
         uint32 strobe_skip = 11; // 2MHz periods to skip after strobe
         uint32 strobe_delay = 12; // offset from 2MHz to start strobe in 64MHz periods
@@ -143,6 +144,8 @@ message ConfigureWIB {
     ConfigureCOLDADC adc_conf = 5; // specify non-hardcoded values for COLDADC (omit for defaults)
     
     bool frame_dd = 6; // enable Frame-DD from COLDATA instead of Frame-14 data
+
+    uint32 detectorType = 7; // 0 for upper APA, 1 for lower APA, 2 for CRP
     
     //replies Status
 }

--- a/src/wib.proto
+++ b/src/wib.proto
@@ -145,7 +145,7 @@ message ConfigureWIB {
     
     bool frame_dd = 6; // enable Frame-DD from COLDATA instead of Frame-14 data
 
-    uint32 detectorType = 7; // 0 for upper APA, 1 for lower APA, 2 for CRP
+    uint32 detector_type = 7; // 0 for WIB guess, 1 for upper APA, 2 for lower APA, 3 for CRP
     
     //replies Status
 }


### PR DESCRIPTION
Added two fields to WIB configuration:

- gain_match: when true, automatically scales pulser amplitudes according to the LArASIC gain setting. True by default
- detector_type: identifies whether the WIB is reading an upper APA (1), lower APA (2), or CRP (3). The default value of 0 tells the WIB to set this field for itself depending on its crate number 

The conf command will now also issue a timing reset before the configuration command if appropriate. The check_timing() function in the configurator has also been updated.