### PR TITLE
JCF: move README.md to a standard area and update links to point to o…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,9 +5,9 @@ WIB configuration and monitoring interface for DUNE's appfwk.
 ## Testing
 
 A python utility is included to generate metadata to test control of multiple 
-WIBs with [nanorc](https://github.com/DUNE-DAQ/nanorc). This metadata is a set
+WIBs with [nanorc](https://dune-daq-sw.readthedocs.io/en/latest/packages/nanorc). This metadata is a set
 of JSON files that describe the DAQ applications (consisting of interconnected
-[appfwk](https://github.com/DUNE-DAQ/appfwk) modules) and commands these 
+[appfwk](https://dune-daq-sw.readthedocs.io/en/latest/packages/appfwk) modules) and commands these 
 applications (modules) can receive.
 
 ### Generate a WIB application


### PR DESCRIPTION
…fficial documentation, not GitHub