### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/wibmod/Issues.hpp
+++ b/include/wibmod/Issues.hpp
@@ -11,6 +11,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 #include <iomanip>

--- a/include/wibmod/Issues.hpp
+++ b/include/wibmod/Issues.hpp
@@ -11,7 +11,7 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 #include <iomanip>


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)