### PR TITLE
Add and use FEMB enable flags to WIBModule configuration class

### DIFF
--- a/plugins/WIBModule.cpp
+++ b/plugins/WIBModule.cpp
@@ -70,18 +70,18 @@ WIBModule::femb_conf_i(size_t i)
   }
 }
 
-boot
+bool
 WIBModule::femb_enabled_i(size_t i)
 {
   switch(i) {
     case 0:
-      return m_wib_settings->get_femb0_enabled();
+      return m_wib_conf->get_enabled_femb0();
     case 1:
-      return m_wib_settings->get_femb1_enabled();
+      return m_wib_conf->get_enabled_femb1();
     case 2:
-      return m_wib_settings->get_femb2_enabled();
+      return m_wib_conf->get_enabled_femb2();
     case 3:
-      return m_wib_settings->get_femb3_enabled();
+      return m_wib_conf->get_enabled_femb3();
     default:
       throw UnreachableError(ERS_HERE, get_name());
   }
@@ -216,7 +216,7 @@ WIBModule::do_settings()
     TLOG() << "Building FEMB " << iFEMB << " config for " << get_name();
     wib::ConfigureWIB::ConfigureFEMB *femb_conf = req.add_fembs();
     populate_femb_conf(femb_conf, femb_conf_i(iFEMB));
-    femb_conf->set_enabled(femb_conf->get_enabled() and this->femb_enabled_i(i));
+    femb_conf->set_enabled(femb_conf->enabled() and this->femb_enabled_i(iFEMB));
   }
 
 

--- a/plugins/WIBModule.cpp
+++ b/plugins/WIBModule.cpp
@@ -47,7 +47,6 @@ void
 WIBModule::init(std::shared_ptr<appfwk::ConfigurationManager> mcfg)
 {
   m_wib_conf = mcfg->get_dal<appmodel::WIBModule>(get_name());
-  //m_wib_conf = dal->get_conf(); //mcfg->get_dal<appmodel::WIBConf>(get_name());
   if (!m_wib_conf) {
     throw appfwk::CommandFailed(ERS_HERE, "init", get_name(), "Unable to retrieve configuration object");
   }
@@ -71,10 +70,27 @@ WIBModule::femb_conf_i(size_t i)
   }
 }
 
+boot
+WIBModule::femb_enabled_i(size_t i)
+{
+  switch(i) {
+    case 0:
+      return m_wib_settings->get_femb0_enabled();
+    case 1:
+      return m_wib_settings->get_femb1_enabled();
+    case 2:
+      return m_wib_settings->get_femb2_enabled();
+    case 3:
+      return m_wib_settings->get_femb3_enabled();
+    default:
+      throw UnreachableError(ERS_HERE, get_name());
+  }
+}
+
 void
 WIBModule::populate_femb_conf(wib::ConfigureWIB::ConfigureFEMB *femb_conf, const appmodel::FEMBSettings* conf)
 {
-  // femb_conf->set_enabled(conf->get_enabled());
+  femb_conf->set_enabled(conf->get_enabled());
 
   femb_conf->set_test_cap(conf->get_test_cap() != 0);
   femb_conf->set_gain(conf->get_gain());
@@ -195,20 +211,12 @@ WIBModule::do_settings()
   wib_pulser_conf->set_pulse_duration(wib_pulser->get_pulse_duration());
   req.set_allocated_wib_pulser(wib_pulser_conf);
 
-  // Use a bool array for convenience
-  bool femb_enabled[4] = {
-    m_wib_settings->get_femb0_enabled(),
-    m_wib_settings->get_femb1_enabled(),
-    m_wib_settings->get_femb2_enabled(),
-    m_wib_settings->get_femb3_enabled(),
-  };
-
   for(size_t iFEMB = 0; iFEMB < 4; iFEMB++)
   {
     TLOG() << "Building FEMB " << iFEMB << " config for " << get_name();
     wib::ConfigureWIB::ConfigureFEMB *femb_conf = req.add_fembs();
     populate_femb_conf(femb_conf, femb_conf_i(iFEMB));
-    femb_conf->set_enabled(femb_enabled[i]);
+    femb_conf->set_enabled(femb_conf->get_enabled() and this->femb_enabled_i(i));
   }
 
 

--- a/plugins/WIBModule.cpp
+++ b/plugins/WIBModule.cpp
@@ -74,7 +74,7 @@ WIBModule::femb_conf_i(size_t i)
 void
 WIBModule::populate_femb_conf(wib::ConfigureWIB::ConfigureFEMB *femb_conf, const appmodel::FEMBSettings* conf)
 {
-  femb_conf->set_enabled(conf->get_enabled());
+  // femb_conf->set_enabled(conf->get_enabled());
 
   femb_conf->set_test_cap(conf->get_test_cap() != 0);
   femb_conf->set_gain(conf->get_gain());
@@ -195,12 +195,22 @@ WIBModule::do_settings()
   wib_pulser_conf->set_pulse_duration(wib_pulser->get_pulse_duration());
   req.set_allocated_wib_pulser(wib_pulser_conf);
 
+  // Use a bool array for convenience
+  bool femb_enabled[4] = {
+    m_wib_settings->get_femb0_enabled(),
+    m_wib_settings->get_femb1_enabled(),
+    m_wib_settings->get_femb2_enabled(),
+    m_wib_settings->get_femb3_enabled(),
+  };
+
   for(size_t iFEMB = 0; iFEMB < 4; iFEMB++)
   {
     TLOG() << "Building FEMB " << iFEMB << " config for " << get_name();
     wib::ConfigureWIB::ConfigureFEMB *femb_conf = req.add_fembs();
     populate_femb_conf(femb_conf, femb_conf_i(iFEMB));
+    femb_conf->set_enabled(femb_enabled[i]);
   }
+
 
   TLOG() << "Sending WIB configuration to " << get_name();
   wib::Status rep;

--- a/plugins/WIBModule.hpp
+++ b/plugins/WIBModule.hpp
@@ -68,6 +68,7 @@ private:
   // Helpers
   void populate_femb_conf(wib::ConfigureWIB::ConfigureFEMB *femb_conf, const appmodel::FEMBSettings* conf);
   const appmodel::FEMBSettings* femb_conf_i(size_t i);
+  bool femb_enabled_i(size_t i);
 
 };
 


### PR DESCRIPTION
`enable_femb*` attributes have been added to WIBModule configuration class to support FEMB masking based on the masking of the associated detector streams.
This PR uses the new flags to enable/disable the FEMBs in or with the FEMB enable flag in the FEMBSetting object.